### PR TITLE
Check for all different packages of opencv

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -175,9 +175,22 @@ if _onnx_available:
 # (sayakpaul): importlib.util.find_spec("opencv-python") returns None even when it's installed.
 # _opencv_available = importlib.util.find_spec("opencv-python") is not None
 try:
-    _opencv_version = importlib_metadata.version("opencv-python")
-    _opencv_available = True
-    logger.debug(f"Successfully imported cv2 version {_opencv_version}")
+    candidates = (
+        "opencv-python",
+        "opencv-contrib-python",
+        "opencv-python-headless",
+        "opencv-contrib-python-headless",
+    )
+    _opencv_version = None
+    for pkg in candidates:
+        try:
+            _opencv_version = importlib_metadata.version(pkg)
+            break
+        except importlib_metadata.PackageNotFoundError:
+            pass
+    _opencv_available = _opencv_version is not None
+    if _opencv_available:
+        logger.debug(f"Successfully imported cv2 version {_opencv_version}")
 except importlib_metadata.PackageNotFoundError:
     _opencv_available = False
 


### PR DESCRIPTION
The existing check for opencv only covers the main package `opencv-python`. However, there exist four different packages for opencv:
- `opencv-python` - main package
- `opencv-contrib-python` - full package (comes with contrib/extra modules)
- `opencv-python-headless` - main package without GUI
- `opencv-contrib-python-headless` - full package without GUI

This PR ensures that `diffusers` will not raise import error when using cv2-related functions as long as they have installed any of the packages above.